### PR TITLE
Crear card de cambio de contraseña

### DIFF
--- a/apps/website/src/app/dashboard/components/wrapper.tsx
+++ b/apps/website/src/app/dashboard/components/wrapper.tsx
@@ -10,7 +10,7 @@ export const AristocratPageWrapper = (props: AristocratPageWrapperProps) => {
 	const { children } = props;
 
 	return (
-		<div className="w-full flex-1 bg-background shadow-md md:rounded-s-[inherit] min-[1024px]:rounded-e-3xl">
+		<div className="w-full flex-1 bg-background md:rounded-s-[inherit] min-[1024px]:rounded-e-3xl">
 			<div className="flex h-full flex-col px-4 md:px-6 lg:px-8">
 				<AristocratBreadcrumb action={props.action} />
 				<div className="relative grow">

--- a/apps/website/src/app/dashboard/settings/components/forms/password.tsx
+++ b/apps/website/src/app/dashboard/settings/components/forms/password.tsx
@@ -88,7 +88,7 @@ export function SettingsPasswordForm() {
 								<Input
 									id={field.name}
 									name={field.name}
-									type="text"
+									type="password"
 									value={field.state.value}
 									onBlur={field.handleBlur}
 									className="mt-1 bg-secondary text-secondary-foreground"

--- a/apps/website/src/app/dashboard/settings/components/forms/password.tsx
+++ b/apps/website/src/app/dashboard/settings/components/forms/password.tsx
@@ -61,7 +61,7 @@ export function SettingsPasswordForm() {
 								<Input
 									id={field.name}
 									name={field.name}
-									type="text"
+									type="password"
 									value={field.state.value}
 									onBlur={field.handleBlur}
 									className="mt-1 bg-secondary text-secondary-foreground"

--- a/apps/website/src/app/dashboard/settings/components/forms/password.tsx
+++ b/apps/website/src/app/dashboard/settings/components/forms/password.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import z from 'zod/v4';
+
+import { useForm } from '@tanstack/react-form';
+
+import { authenticationClientside } from '@/lib/auth-client';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { CardAction, CardContent, CardFooter } from '@/components/ui/card';
+
+const settingsPasswordFormValidators = {
+	onSubmit: z
+		.object({
+			currentPassword: z.string().min(1, 'La contraseña actual es obligatoria'),
+			newPassword: z
+				.string()
+				.min(8, 'La contraseña debe tener al menos 8 caracteres')
+				.max(30, 'La contraseña no puede tener más de 30 caracteres'),
+		})
+		.refine((data) => data.currentPassword !== data.newPassword, {
+			message: 'La nueva contraseña debe ser diferente a la contraseña actual',
+			path: ['newPassword'],
+		}),
+};
+
+export function SettingsPasswordForm() {
+	const settingsPasswordFormInstance = useForm({
+		defaultValues: { currentPassword: '', newPassword: '' },
+		validators: settingsPasswordFormValidators,
+		onSubmit: async ({ value }) => {
+			await authenticationClientside.changePassword(value, {
+				onSuccess: () => {
+					toast.success('Contraseña actualizada correctamente');
+				},
+				onError: (error) => {
+					toast.error(error.error.message);
+				},
+			});
+		},
+	});
+
+	const handleSubmitRegisterForm = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+		void settingsPasswordFormInstance.handleSubmit();
+	};
+
+	return (
+		<form onSubmit={handleSubmitRegisterForm}>
+			<CardContent className="grid grid-cols-1 gap-6 pt-4 lg:grid-cols-2">
+				<div>
+					<settingsPasswordFormInstance.Field name="currentPassword">
+						{(field) => (
+							<div className="space-y-2">
+								<Label htmlFor={field.name}>Contraseña actual</Label>
+								<Input
+									id={field.name}
+									name={field.name}
+									type="text"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									className="mt-1 bg-secondary text-secondary-foreground"
+									onChange={(e) => field.handleChange(e.target.value)}
+								/>
+								{field.state.meta.errors.map((error) => (
+									<p
+										key={error?.message}
+										className="text-muted-foreground text-xs"
+									>
+										{error?.message}
+									</p>
+								))}
+							</div>
+						)}
+					</settingsPasswordFormInstance.Field>
+				</div>
+
+				<div>
+					<settingsPasswordFormInstance.Field name="newPassword">
+						{(field) => (
+							<div className="space-y-2">
+								<Label htmlFor={field.name}>Nueva contraseña</Label>
+								<Input
+									id={field.name}
+									name={field.name}
+									type="text"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									className="mt-1 bg-secondary text-secondary-foreground"
+									onChange={(e) => field.handleChange(e.target.value)}
+								/>
+								<div>
+									{field.state.meta.errors.map((error) => (
+										<p
+											key={error?.message}
+											className="text-muted-foreground text-xs"
+										>
+											{error?.message}
+										</p>
+									))}
+								</div>
+							</div>
+						)}
+					</settingsPasswordFormInstance.Field>
+				</div>
+			</CardContent>
+
+			<CardFooter className="mt-4 justify-end border-t pt-4!">
+				<CardAction>
+					<settingsPasswordFormInstance.Subscribe>
+						{(state) => (
+							<Button
+								type="submit"
+								className="text-sm"
+								disabled={
+									!state.canSubmit || state.isSubmitting || !state.isDirty
+								}
+							>
+								{state.isSubmitting ? 'Procesando...' : 'Actualizar contraseña'}
+							</Button>
+						)}
+					</settingsPasswordFormInstance.Subscribe>
+				</CardAction>
+			</CardFooter>
+		</form>
+	);
+}

--- a/apps/website/src/app/dashboard/settings/components/forms/profile.tsx
+++ b/apps/website/src/app/dashboard/settings/components/forms/profile.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import z from 'zod/v4';
+
+import { useId } from 'react';
+import { useForm } from '@tanstack/react-form';
+
+import { authenticationClientside } from '@/lib/auth-client';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { CardAction, CardContent, CardFooter } from '@/components/ui/card';
+
+const settingsProfileFormValidators = {
+	onSubmit: z.object({
+		name: z
+			.string()
+			.min(1, 'El nombre es obligatorio')
+			.max(50, 'El nombre no puede tener más de 50 caracteres'),
+	}),
+};
+
+export function SettingsProfileForm() {
+	const { data } = authenticationClientside.useSession();
+
+	const settingsProfileFormInstance = useForm({
+		defaultValues: { name: data?.user.name || '' },
+		validators: settingsProfileFormValidators,
+		onSubmit: async ({ value }) => {
+			await authenticationClientside.updateUser(value, {
+				onSuccess: () => {
+					toast.success('Perfil actualizado correctamente');
+				},
+				onError: (error) => {
+					toast.error(error.error.message);
+				},
+			});
+		},
+	});
+
+	const handleSubmitRegisterForm = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+		void settingsProfileFormInstance.handleSubmit();
+	};
+
+	return (
+		<form onSubmit={handleSubmitRegisterForm}>
+			<CardContent className="grid grid-cols-1 gap-6 pt-4 lg:grid-cols-2">
+				<div>
+					<div className="space-y-2">
+						<Label htmlFor="email">Email</Label>
+						<Input
+							disabled
+							id={useId()}
+							name="email"
+							type="text"
+							className="mt-1 bg-secondary"
+							value={data?.user?.email || ''}
+						/>
+					</div>
+				</div>
+
+				<div>
+					<settingsProfileFormInstance.Field name="name">
+						{(field) => (
+							<div className="space-y-2">
+								<Label htmlFor={field.name}>Nombre completo</Label>
+								<Input
+									id={field.name}
+									name={field.name}
+									type="text"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									className="mt-1 bg-secondary text-secondary-foreground"
+									onChange={(e) => field.handleChange(e.target.value)}
+								/>
+								{field.state.meta.errors.map((error) => (
+									<p
+										key={error?.message}
+										className="text-muted-foreground text-xs"
+									>
+										{error?.message}
+									</p>
+								))}
+							</div>
+						)}
+					</settingsProfileFormInstance.Field>
+				</div>
+			</CardContent>
+
+			<CardFooter className="mt-4 justify-end border-t pt-4!">
+				<CardAction>
+					<settingsProfileFormInstance.Subscribe>
+						{(state) => (
+							<Button
+								type="submit"
+								className="text-sm"
+								disabled={
+									!state.canSubmit || state.isSubmitting || !state.isDirty
+								}
+							>
+								{state.isSubmitting ? 'Procesando...' : 'Guardar cambios'}
+							</Button>
+						)}
+					</settingsProfileFormInstance.Subscribe>
+				</CardAction>
+			</CardFooter>
+		</form>
+	);
+}

--- a/apps/website/src/app/dashboard/settings/components/forms/profile.tsx
+++ b/apps/website/src/app/dashboard/settings/components/forms/profile.tsx
@@ -52,10 +52,10 @@ export function SettingsProfileForm() {
 			<CardContent className="grid grid-cols-1 gap-6 pt-4 lg:grid-cols-2">
 				<div>
 					<div className="space-y-2">
-						<Label htmlFor="email">Email</Label>
+						<Label htmlFor={emailId}>Email</Label>
 						<Input
 							disabled
-							id={useId()}
+							id={emailId}
 							name="email"
 							type="text"
 							className="mt-1 bg-secondary"

--- a/apps/website/src/app/dashboard/settings/page.tsx
+++ b/apps/website/src/app/dashboard/settings/page.tsx
@@ -1,9 +1,12 @@
 import { AristocratPageHeader } from '@/app/dashboard/components/header';
 import { AristocratPageWrapper } from '@/app/dashboard/components/wrapper';
 
-import { AristocratDashboardSettingsSidebar } from './components/sidebar';
-import { AristocratDashboardSettingsCards } from './components/cards';
-import { SettingsProfileForm } from './components/form';
+import { AristocratDashboardSettingsSidebar } from '@/app/dashboard/settings/components/sidebar';
+import { AristocratDashboardSettingsCards } from '@/app/dashboard/settings/components/cards';
+
+import { SettingsProfileForm } from '@/app/dashboard/settings/components/forms/profile';
+import { SettingsPasswordForm } from '@/app/dashboard/settings/components/forms/password';
+import { SettingsAvatarForm } from '@/app/dashboard/settings/components/forms/avatar';
 
 const AristocratDashboardSettingsPage = () => (
 	<AristocratPageWrapper>
@@ -23,11 +26,21 @@ const AristocratDashboardSettingsPage = () => (
 							'Actualiza tu información personal y preferencias de cuenta.',
 					}}
 				/>
+
 				<AristocratDashboardSettingsCards
-					form={<></>}
+					form={<SettingsAvatarForm />}
+					content={{
+						title: 'Mi Avatar',
+						description: 'Personaliza tu imagen y deja una impresión única.',
+					}}
+				/>
+
+				<AristocratDashboardSettingsCards
+					form={<SettingsPasswordForm />}
 					content={{
 						title: 'Seguridad',
-						description: 'Actualiza tu contraseña y opciones de seguridad.',
+						description:
+							'Cambia tu contraseña y gestiona la seguridad de tu cuenta.',
 					}}
 				/>
 			</div>

--- a/apps/website/src/components/navigation/header/user.tsx
+++ b/apps/website/src/components/navigation/header/user.tsx
@@ -21,7 +21,7 @@ export const AristocratNavigationHeaderUser = () => {
 	const { data, isPending } = authenticationClientside.useSession();
 
 	if (isPending) {
-		return <Skeleton className="size-8 rounded-full" />;
+		return <Skeleton className="size-8 rounded-lg" />;
 	}
 
 	return (


### PR DESCRIPTION
This pull request introduces enhancements to the user dashboard's settings page, including new forms for managing profile, password, and avatar, along with minor UI adjustments. The changes improve functionality and user experience by adding validation, interactivity, and updated styling.

### New Features and Enhancements:

* **Password Management Form**: Added `SettingsPasswordForm` with validation for current and new passwords, ensuring the new password is different from the current one. Includes success and error handling using `toast`. (`apps/website/src/app/dashboard/settings/components/forms/password.tsx`)
* **Profile Management Form**: Added `SettingsProfileForm` for updating user names with validation, while displaying email as a disabled field. Includes success and error handling using `toast`. (`apps/website/src/app/dashboard/settings/components/forms/profile.tsx`)
* **Avatar Management Form**: Integrated `SettingsAvatarForm` into the settings page for customizing user avatars. (`apps/website/src/app/dashboard/settings/page.tsx`)

### UI and Styling Updates:

* **Wrapper Component Styling**: Removed `shadow-md` class from the `AristocratPageWrapper` component for cleaner visuals. (`apps/website/src/app/dashboard/components/wrapper.tsx`)
* **Skeleton Loader Styling**: Updated the `Skeleton` component in the navigation header to use `rounded-lg` instead of `rounded-full`. (`apps/website/src/components/navigation/header/user.tsx`)