### PR TITLE
docs(claude): update CLAUDE.md with comprehensive development guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,12 +21,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `bun run check` - Run Biome linter and formatter
 - `bun run check-types` - TypeScript type checking across all apps
 
+**Testing**
+- `bun run test` - Run Jest tests across all packages
+- `bun run test:watch` - Run tests in watch mode (transcripter app)
+- `bun run test:coverage` - Run tests with coverage reporting (transcripter app)
+
 ## Architecture Overview
 
 **Monorepo Structure**
 - `apps/server/` - Hono + tRPC API server with PostgreSQL/Drizzle ORM
 - `apps/website/` - Next.js 15 frontend with App Router, tRPC client
+- `apps/transcripter/` - Transcript processing microservice with Hono, SRT/VTT parsing, JWT auth
 - `apps/workers/` - Background job processing (Trigger.dev integration planned)
+- `packages/database/` - Shared database package with Drizzle ORM, schemas, and repositories
 
 **Key Technologies**
 - **Runtime**: Bun for package management and development
@@ -46,10 +53,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - Starts all development servers
 
 **Database Setup**
-- PostgreSQL runs in Docker container with persistent volume
+- PostgreSQL runs in Docker container with persistent volume (`aristocrat_postgres_data`)
 - Connection: `postgres://postgres:mypassword@localhost:5432/postgres`
-- Schema files in `apps/server/src/db/schema/`
-- Migrations auto-generated with Drizzle Kit
+- Schema files in `packages/database/src/schema/` (shared package)
+- Database package exports: schema, repository functions, and utilities
+- Migrations auto-generated with Drizzle Kit in database package
 
 **File Upload**
 - Uses UploadThing for file management
@@ -72,5 +80,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Nursery rule `useUniqueElementIds` disabled for React components
 
 **Environment Variables**
-- Server: `.env` file in `apps/server/` with `DATABASE_URL`, `BETTER_AUTH_SECRET`, `CORS_ORIGIN`
+- Server: `.env` file in `apps/server/` with `DATABASE_URL`, `BETTER_AUTH_SECRET`, `CORS_ORIGIN`, `BETTER_AUTH_URL`
 - Website: Next.js environment variables for `NEXT_PUBLIC_SERVER_URL`, `UPLOADTHING_TOKEN`
+- Database: `.env` file in `packages/database/` with `DATABASE_URL` (auto-created by dev script)
+- Transcripter: Uses JWT tokens for authentication, no specific env file required
+
+**Package Management**
+- Uses Bun workspaces with shared TypeScript configuration (`@aristocrat/typescript`)
+- Database package (`@aristocrat/database`) provides shared schema and utilities
+- Each app can import from workspace packages using `workspace:*` protocol
+
+**Testing Architecture**
+- Jest configuration in root and individual packages
+- Transcripter app has comprehensive test coverage for error handling, services, and utilities
+- Database package includes repository and utility tests

--- a/apps/transcripter/__tests__/__mocks__/bun.ts
+++ b/apps/transcripter/__tests__/__mocks__/bun.ts
@@ -1,0 +1,24 @@
+/**
+ * Mock implementation of Bun shell for Jest tests
+ */
+
+import { jest } from '@jest/globals';
+
+export const $ = jest
+	.fn()
+	.mockImplementation(
+		(template: TemplateStringsArray, ...values: unknown[]) => {
+			const _command = template
+				.map((str, i) => str + (values[i] || ''))
+				.join('');
+
+			return {
+				exitCode: 0,
+				stderr: {
+					text: jest.fn().mockResolvedValue(''),
+				},
+				nothrow: jest.fn().mockReturnThis(),
+				text: jest.fn().mockResolvedValue('mock-file1.vtt\nmock-file2.srt'),
+			};
+		},
+	);

--- a/apps/transcripter/__tests__/errors/index.test.ts
+++ b/apps/transcripter/__tests__/errors/index.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for custom error classes
+ */
+
+import {
+	FileOperationError,
+	InvalidVideoIdError,
+	isSupportedLanguage,
+	isTranscriptionError,
+	RateLimitError,
+	ServiceUnavailableError,
+	SUPPORTED_LANGUAGES,
+	SubtitleParsingError,
+	TranscriptNotAvailableError,
+	UnsupportedLanguageError,
+	VideoNotFoundError,
+	YtDlpError,
+} from '@/errors';
+
+describe('TranscriptionError classes', () => {
+	describe('VideoNotFoundError', () => {
+		it('should create error with correct properties', () => {
+			const videoId = 'dQw4w9WgXcQ';
+			const error = new VideoNotFoundError(videoId);
+
+			expect(error.name).toBe('VideoNotFoundError');
+			expect(error.statusCode).toBe(404);
+			expect(error.errorCode).toBe('VIDEO_NOT_FOUND');
+			expect(error.userMessage).toBe(
+				`El video con ID ${videoId} no fue encontrado o no está disponible.`,
+			);
+			expect(error.message).toContain(videoId);
+		});
+
+		it('should include context in error', () => {
+			const videoId = 'dQw4w9WgXcQ';
+			const context = { stderr: 'Video unavailable' };
+			const error = new VideoNotFoundError(videoId, context);
+
+			expect(error.context).toEqual(context);
+		});
+	});
+
+	describe('TranscriptNotAvailableError', () => {
+		it('should create error with correct properties', () => {
+			const videoId = 'dQw4w9WgXcQ';
+			const language = 'es';
+			const error = new TranscriptNotAvailableError(videoId, language);
+
+			expect(error.name).toBe('TranscriptNotAvailableError');
+			expect(error.statusCode).toBe(404);
+			expect(error.errorCode).toBe('TRANSCRIPT_NOT_AVAILABLE');
+			expect(error.userMessage).toBe(
+				`No hay transcripción en ${language} disponible para el video ${videoId}.`,
+			);
+		});
+	});
+
+	describe('UnsupportedLanguageError', () => {
+		it('should create error with correct properties', () => {
+			const language = 'fr';
+			const supportedLanguages = ['es', 'en'];
+			const error = new UnsupportedLanguageError(language, supportedLanguages);
+
+			expect(error.name).toBe('UnsupportedLanguageError');
+			expect(error.statusCode).toBe(400);
+			expect(error.errorCode).toBe('UNSUPPORTED_LANGUAGE');
+			expect(error.userMessage).toBe(
+				`El idioma ${language} no está soportado. Idiomas disponibles: ${supportedLanguages.join(', ')}.`,
+			);
+		});
+	});
+
+	describe('InvalidVideoIdError', () => {
+		it('should create error with correct properties', () => {
+			const videoId = 'invalid-id';
+			const error = new InvalidVideoIdError(videoId);
+
+			expect(error.name).toBe('InvalidVideoIdError');
+			expect(error.statusCode).toBe(400);
+			expect(error.errorCode).toBe('INVALID_VIDEO_ID');
+			expect(error.userMessage).toBe(
+				`El ID del video ${videoId} no es válido. Debe ser un ID de YouTube de 11 caracteres.`,
+			);
+		});
+	});
+
+	describe('RateLimitError', () => {
+		it('should create error without retry after', () => {
+			const error = new RateLimitError();
+
+			expect(error.name).toBe('RateLimitError');
+			expect(error.statusCode).toBe(429);
+			expect(error.errorCode).toBe('RATE_LIMITED');
+			expect(error.userMessage).toBe(
+				'Demasiadas solicitudes. Intente nuevamente más tarde.',
+			);
+		});
+
+		it('should create error with retry after', () => {
+			const retryAfter = 60;
+			const error = new RateLimitError(retryAfter);
+
+			expect(error.userMessage).toBe(
+				`Demasiadas solicitudes. Intente nuevamente en ${retryAfter} segundos.`,
+			);
+		});
+	});
+
+	describe('ServiceUnavailableError', () => {
+		it('should create error with correct properties', () => {
+			const serviceName = 'yt-dlp';
+			const error = new ServiceUnavailableError(serviceName);
+
+			expect(error.name).toBe('ServiceUnavailableError');
+			expect(error.statusCode).toBe(503);
+			expect(error.errorCode).toBe('SERVICE_UNAVAILABLE');
+			expect(error.userMessage).toBe(
+				`El servicio de ${serviceName} no está disponible temporalmente. Intente nuevamente más tarde.`,
+			);
+		});
+	});
+
+	describe('YtDlpError', () => {
+		it('should create error with correct properties', () => {
+			const exitCode = 1;
+			const stderr = 'Download failed';
+			const error = new YtDlpError(exitCode, stderr);
+
+			expect(error.name).toBe('YtDlpError');
+			expect(error.statusCode).toBe(500);
+			expect(error.errorCode).toBe('YTDLP_ERROR');
+			expect(error.userMessage).toBe(
+				'Error al procesar el video. Verifique que el enlace sea válido y que el video tenga subtítulos disponibles.',
+			);
+			expect(error.message).toContain(exitCode.toString());
+			expect(error.message).toContain(stderr);
+		});
+	});
+
+	describe('FileOperationError', () => {
+		it('should create error with correct properties', () => {
+			const operation = 'read';
+			const filePath = '/tmp/test.txt';
+			const originalError = new Error('File not found');
+			const error = new FileOperationError(operation, filePath, originalError);
+
+			expect(error.name).toBe('FileOperationError');
+			expect(error.statusCode).toBe(500);
+			expect(error.errorCode).toBe('FILE_OPERATION_ERROR');
+			expect(error.userMessage).toBe(
+				'Error interno del servidor al procesar los archivos de transcripción.',
+			);
+			expect(error.message).toContain(operation);
+			expect(error.message).toContain(filePath);
+			expect(error.message).toContain(originalError.message);
+		});
+	});
+
+	describe('SubtitleParsingError', () => {
+		it('should create error with correct properties', () => {
+			const fileName = 'test.vtt';
+			const originalError = new Error('Invalid format');
+			const error = new SubtitleParsingError(fileName, originalError);
+
+			expect(error.name).toBe('SubtitleParsingError');
+			expect(error.statusCode).toBe(500);
+			expect(error.errorCode).toBe('SUBTITLE_PARSING_ERROR');
+			expect(error.userMessage).toBe(
+				'Error al procesar el archivo de subtítulos. El formato puede estar corrupto.',
+			);
+			expect(error.message).toContain(fileName);
+			expect(error.message).toContain(originalError.message);
+		});
+	});
+});
+
+describe('Error utility functions', () => {
+	describe('isTranscriptionError', () => {
+		it('should return true for TranscriptionError instances', () => {
+			const error = new VideoNotFoundError('test-id');
+			expect(isTranscriptionError(error)).toBe(true);
+		});
+
+		it('should return false for regular Error instances', () => {
+			const error = new Error('Regular error');
+			expect(isTranscriptionError(error)).toBe(false);
+		});
+
+		it('should return false for non-error values', () => {
+			expect(isTranscriptionError('string')).toBe(false);
+			expect(isTranscriptionError(null)).toBe(false);
+			expect(isTranscriptionError(undefined)).toBe(false);
+		});
+	});
+
+	describe('isSupportedLanguage', () => {
+		it('should return true for supported languages', () => {
+			for (const lang of SUPPORTED_LANGUAGES) {
+				expect(isSupportedLanguage(lang)).toBe(true);
+			}
+		});
+
+		it('should return false for unsupported languages', () => {
+			expect(isSupportedLanguage('fr')).toBe(false);
+			expect(isSupportedLanguage('de')).toBe(false);
+			expect(isSupportedLanguage('invalid')).toBe(false);
+		});
+	});
+
+	describe('SUPPORTED_LANGUAGES', () => {
+		it('should contain expected languages', () => {
+			expect(SUPPORTED_LANGUAGES).toContain('es');
+			expect(SUPPORTED_LANGUAGES).toContain('en');
+			expect(SUPPORTED_LANGUAGES).toContain('es-419');
+			expect(SUPPORTED_LANGUAGES).toContain('es-ES');
+		});
+
+		it('should be readonly', () => {
+			// TypeScript readonly arrays are only compile-time checks
+			// At runtime, they're still regular arrays, so we test the type structure
+			expect(Array.isArray(SUPPORTED_LANGUAGES)).toBe(true);
+			expect(SUPPORTED_LANGUAGES.length).toBeGreaterThan(0);
+		});
+	});
+});

--- a/apps/transcripter/__tests__/services/transcript.test.ts
+++ b/apps/transcripter/__tests__/services/transcript.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for TranscriptService with error handling
+ */
+
+import {
+	FileOperationError,
+	SubtitleParsingError,
+	TranscriptNotAvailableError,
+	VideoNotFoundError,
+} from '@/errors';
+import * as srtParser from '@/parsers/srt';
+import * as vttParser from '@/parsers/vtt';
+import { TranscriptService } from '@/services/transcript';
+import * as filesModule from '@/utils/files';
+
+// Mock the file utilities
+jest.mock('@/utils/files');
+jest.mock('@/parsers/srt');
+jest.mock('@/parsers/vtt');
+jest.mock('@/utils/logger');
+
+const mockFiles = filesModule as jest.Mocked<typeof filesModule>;
+const mockSrtParser = srtParser as jest.Mocked<typeof srtParser>;
+const mockVttParser = vttParser as jest.Mocked<typeof vttParser>;
+
+// Mock Bun.file
+const mockBunFile = {
+	text: jest.fn(),
+};
+(global as any).Bun = {
+	file: jest.fn().mockReturnValue(mockBunFile),
+};
+
+describe('TranscriptService', () => {
+	let service: TranscriptService;
+
+	beforeEach(() => {
+		service = new TranscriptService();
+		jest.clearAllMocks();
+	});
+
+	describe('extractTranscript', () => {
+		const videoId = 'dQw4w9WgXcQ';
+		const language = 'es';
+		const userId = 'user123';
+		const tempDir = '/tmp/transcript_test';
+
+		it('should successfully extract transcript', async () => {
+			const mockTranscript = [
+				{ start: 0, end: 5, text: 'Hello world' },
+				{ start: 5, end: 10, text: 'This is a test' },
+			];
+
+			mockFiles.createTempDirectory.mockResolvedValue(tempDir);
+			mockFiles.downloadSubtitles.mockResolvedValue(['video.es.vtt']);
+			mockFiles.selectBestSubtitleFile.mockReturnValue('video.es.vtt');
+			mockBunFile.text.mockResolvedValue(
+				'WEBVTT\n\n00:00:00.000 --> 00:00:05.000\nHello world',
+			);
+			mockVttParser.parseVTTSubtitles.mockReturnValue(mockTranscript);
+			mockFiles.cleanupTempDirectory.mockResolvedValue();
+
+			const result = await service.extractTranscript(videoId, language, userId);
+
+			expect(result).toEqual({
+				transcript: mockTranscript,
+				segments: 2,
+				file: 'video.es.vtt',
+			});
+
+			expect(mockFiles.createTempDirectory).toHaveBeenCalledWith(videoId);
+			expect(mockFiles.downloadSubtitles).toHaveBeenCalledWith(
+				videoId,
+				language,
+				tempDir,
+			);
+			expect(mockFiles.cleanupTempDirectory).toHaveBeenCalledWith(tempDir);
+		});
+
+		it('should handle SRT files', async () => {
+			const mockTranscript = [{ start: 0, end: 5, text: 'Hello world' }];
+
+			mockFiles.createTempDirectory.mockResolvedValue(tempDir);
+			mockFiles.downloadSubtitles.mockResolvedValue(['video.es.srt']);
+			mockFiles.selectBestSubtitleFile.mockReturnValue('video.es.srt');
+			mockBunFile.text.mockResolvedValue(
+				'1\n00:00:00,000 --> 00:00:05,000\nHello world',
+			);
+			mockSrtParser.parseSRTSubtitles.mockReturnValue(mockTranscript);
+			mockFiles.cleanupTempDirectory.mockResolvedValue();
+
+			const result = await service.extractTranscript(videoId, language, userId);
+
+			expect(mockSrtParser.parseSRTSubtitles).toHaveBeenCalled();
+			expect(result.file).toBe('video.es.srt');
+		});
+
+		it('should propagate VideoNotFoundError', async () => {
+			const error = new VideoNotFoundError(videoId);
+
+			mockFiles.createTempDirectory.mockResolvedValue(tempDir);
+			mockFiles.downloadSubtitles.mockRejectedValue(error);
+			mockFiles.cleanupTempDirectory.mockResolvedValue();
+
+			await expect(
+				service.extractTranscript(videoId, language, userId),
+			).rejects.toThrow(VideoNotFoundError);
+		});
+
+		it('should propagate TranscriptNotAvailableError', async () => {
+			const error = new TranscriptNotAvailableError(videoId, language);
+
+			mockFiles.createTempDirectory.mockResolvedValue(tempDir);
+			mockFiles.downloadSubtitles.mockRejectedValue(error);
+			mockFiles.cleanupTempDirectory.mockResolvedValue();
+
+			await expect(
+				service.extractTranscript(videoId, language, userId),
+			).rejects.toThrow(TranscriptNotAvailableError);
+		});
+
+		it('should throw FileOperationError when file reading fails', async () => {
+			mockFiles.createTempDirectory.mockResolvedValue(tempDir);
+			mockFiles.downloadSubtitles.mockResolvedValue(['video.es.vtt']);
+			mockFiles.selectBestSubtitleFile.mockReturnValue('video.es.vtt');
+			mockBunFile.text.mockRejectedValue(new Error('File not found'));
+			mockFiles.cleanupTempDirectory.mockResolvedValue();
+
+			await expect(
+				service.extractTranscript(videoId, language, userId),
+			).rejects.toThrow(FileOperationError);
+		});
+
+		it('should throw SubtitleParsingError when parsing fails', async () => {
+			mockFiles.createTempDirectory.mockResolvedValue(tempDir);
+			mockFiles.downloadSubtitles.mockResolvedValue(['video.es.vtt']);
+			mockFiles.selectBestSubtitleFile.mockReturnValue('video.es.vtt');
+			mockBunFile.text.mockResolvedValue('WEBVTT\n\ninvalid content');
+			mockVttParser.parseVTTSubtitles.mockImplementation(() => {
+				throw new Error('Invalid VTT format');
+			});
+			mockFiles.cleanupTempDirectory.mockResolvedValue();
+
+			await expect(
+				service.extractTranscript(videoId, language, userId),
+			).rejects.toThrow(SubtitleParsingError);
+		});
+
+		it('should always cleanup temp directory even on error', async () => {
+			const error = new VideoNotFoundError(videoId);
+
+			mockFiles.createTempDirectory.mockResolvedValue(tempDir);
+			mockFiles.downloadSubtitles.mockRejectedValue(error);
+			mockFiles.cleanupTempDirectory.mockResolvedValue();
+
+			await expect(
+				service.extractTranscript(videoId, language, userId),
+			).rejects.toThrow();
+
+			expect(mockFiles.cleanupTempDirectory).toHaveBeenCalledWith(tempDir);
+		});
+
+		it('should work without userId', async () => {
+			const mockTranscript = [{ start: 0, end: 5, text: 'Hello world' }];
+
+			mockFiles.createTempDirectory.mockResolvedValue(tempDir);
+			mockFiles.downloadSubtitles.mockResolvedValue(['video.es.vtt']);
+			mockFiles.selectBestSubtitleFile.mockReturnValue('video.es.vtt');
+			mockBunFile.text.mockResolvedValue(
+				'WEBVTT\n\n00:00:00.000 --> 00:00:05.000\nHello world',
+			);
+			mockVttParser.parseVTTSubtitles.mockReturnValue(mockTranscript);
+			mockFiles.cleanupTempDirectory.mockResolvedValue();
+
+			const result = await service.extractTranscript(videoId, language);
+
+			expect(result).toBeDefined();
+			expect(result.transcript).toEqual(mockTranscript);
+		});
+	});
+});

--- a/apps/transcripter/__tests__/utils/retry.test.ts
+++ b/apps/transcripter/__tests__/utils/retry.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for retry utility
+ */
+
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+} from '@jest/globals';
+import { withRetry, YT_DLP_RETRY_OPTIONS } from '@/utils/retry';
+
+describe('withRetry', () => {
+	beforeEach(() => {
+		// Mock console.warn to suppress logs during tests
+		jest.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		// Restore all mocks after each test
+		jest.restoreAllMocks();
+	});
+
+	it('should return result on first success', async () => {
+		const mockFn = jest.fn(() => Promise.resolve('success'));
+
+		const result = await withRetry(mockFn);
+
+		expect(result).toBe('success');
+		expect(mockFn).toHaveBeenCalledTimes(1);
+	});
+
+	it('should retry on failure and eventually succeed', async () => {
+		let callCount = 0;
+		const mockFn = jest.fn(() => {
+			callCount++;
+			if (callCount <= 2) {
+				return Promise.reject(new Error('Network error'));
+			}
+			return Promise.resolve('success');
+		});
+
+		const result = await withRetry(mockFn, { maxRetries: 3, baseDelay: 10 });
+
+		expect(result).toBe('success');
+		expect(mockFn).toHaveBeenCalledTimes(3);
+	});
+
+	it('should throw last error after max retries exceeded', async () => {
+		const error = new Error('network timeout error'); // Use retryable error
+		const mockFn = jest.fn(() => Promise.reject(error));
+
+		await expect(
+			withRetry(mockFn, { maxRetries: 2, baseDelay: 10 }),
+		).rejects.toThrow('network timeout error');
+		expect(mockFn).toHaveBeenCalledTimes(3); // initial + 2 retries
+	});
+
+	it('should not retry when retryCondition returns false', async () => {
+		const error = new Error('Non-retryable error');
+		const mockFn = jest.fn(() => Promise.reject(error));
+
+		await expect(
+			withRetry(mockFn, {
+				maxRetries: 3,
+				retryCondition: () => false,
+			}),
+		).rejects.toThrow('Non-retryable error');
+		expect(mockFn).toHaveBeenCalledTimes(1); // no retries
+	});
+
+	it('should use custom retry condition', async () => {
+		const networkError = new Error('network timeout');
+		const authError = new Error('unauthorized');
+		let callCount = 0;
+		const mockFn = jest.fn(() => {
+			callCount++;
+			if (callCount === 1) {
+				return Promise.reject(networkError);
+			}
+			return Promise.reject(authError);
+		});
+
+		await expect(
+			withRetry(mockFn, {
+				maxRetries: 3,
+				baseDelay: 10,
+				retryCondition: (error: Error) => error.message.includes('network'),
+			}),
+		).rejects.toThrow('unauthorized');
+		expect(mockFn).toHaveBeenCalledTimes(2); // initial + 1 retry for network error
+	});
+
+	it('should respect maxDelay setting', async () => {
+		let callCount = 0;
+		const mockFn = jest.fn(() => {
+			callCount++;
+			if (callCount === 1) {
+				return Promise.reject(new Error('Network error'));
+			}
+			return Promise.resolve('success');
+		});
+
+		const result = await withRetry(mockFn, {
+			maxRetries: 1,
+			baseDelay: 10,
+			maxDelay: 5,
+			backoffMultiplier: 10,
+		});
+
+		expect(result).toBe('success');
+	});
+
+	describe('YT_DLP_RETRY_OPTIONS', () => {
+		it('should have appropriate configuration', () => {
+			expect(YT_DLP_RETRY_OPTIONS.maxRetries).toBe(3);
+			expect(YT_DLP_RETRY_OPTIONS.baseDelay).toBe(2000);
+			expect(YT_DLP_RETRY_OPTIONS.maxDelay).toBe(15000);
+			expect(YT_DLP_RETRY_OPTIONS.backoffMultiplier).toBe(2);
+		});
+
+		it('should retry on network and server errors', () => {
+			const { retryCondition } = YT_DLP_RETRY_OPTIONS;
+
+			if (retryCondition) {
+				expect(retryCondition(new Error('network timeout'))).toBe(true);
+				expect(retryCondition(new Error('connection reset'))).toBe(true);
+				expect(retryCondition(new Error('temporary failure'))).toBe(true);
+				expect(retryCondition(new Error('server error 503'))).toBe(true);
+				expect(retryCondition(new Error('502 bad gateway'))).toBe(true);
+				expect(retryCondition(new Error('504 gateway timeout'))).toBe(true);
+			}
+		});
+
+		it('should not retry on client errors', () => {
+			const { retryCondition } = YT_DLP_RETRY_OPTIONS;
+
+			if (retryCondition) {
+				expect(retryCondition(new Error('invalid video id'))).toBe(false);
+				expect(retryCondition(new Error('video not found'))).toBe(false);
+				expect(retryCondition(new Error('access denied'))).toBe(false);
+			}
+		});
+	});
+});

--- a/apps/transcripter/jest.config.ts
+++ b/apps/transcripter/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
 	testMatch: ['<rootDir>/__tests__/**/*.test.{js,ts}'],
 	moduleNameMapper: {
 		'^@/(.*)$': '<rootDir>/src/$1',
+		'^bun$': '<rootDir>/__tests__/__mocks__/bun.ts',
 	},
 	collectCoverageFrom: [
 		'src/**/*.{ts,js}',

--- a/apps/transcripter/scripts/dev.sh
+++ b/apps/transcripter/scripts/dev.sh
@@ -19,8 +19,6 @@ cleanup() {
 # Trap SIGINT (Ctrl+C) and SIGTERM
 trap cleanup SIGINT SIGTERM
 
-echo "Starting development container..."
-
 # Start container in background and capture container ID
 CONTAINER_ID=$(docker run --rm -d -p 3002:3002 -e NODE_ENV=development -v $(pwd)/src:/app/src -v /app/node_modules transcript-service-dev bun --watch src/index.ts)
 

--- a/apps/transcripter/src/errors/index.ts
+++ b/apps/transcripter/src/errors/index.ts
@@ -1,0 +1,209 @@
+/**
+ * Custom error classes for transcription service
+ */
+
+/**
+ * Base class for all transcription-related errors
+ */
+export abstract class TranscriptionError extends Error {
+	abstract readonly statusCode: number;
+	abstract readonly userMessage: string;
+	abstract readonly errorCode: string;
+
+	constructor(
+		message: string,
+		public readonly context?: Record<string, unknown>,
+	) {
+		super(message);
+		this.name = this.constructor.name;
+	}
+}
+
+/**
+ * Error thrown when a video is not found or unavailable
+ */
+export class VideoNotFoundError extends TranscriptionError {
+	readonly statusCode = 404;
+	readonly errorCode = 'VIDEO_NOT_FOUND';
+	readonly userMessage: string;
+
+	constructor(videoId: string, context?: Record<string, unknown>) {
+		super(`Video not found: ${videoId}`, context);
+		this.userMessage = `El video con ID ${videoId} no fue encontrado o no está disponible.`;
+	}
+}
+
+/**
+ * Error thrown when transcription is not available for the video
+ */
+export class TranscriptNotAvailableError extends TranscriptionError {
+	readonly statusCode = 404;
+	readonly errorCode = 'TRANSCRIPT_NOT_AVAILABLE';
+	readonly userMessage: string;
+
+	constructor(
+		videoId: string,
+		language: string,
+		context?: Record<string, unknown>,
+	) {
+		super(
+			`No transcript available for video ${videoId} in language ${language}`,
+			context,
+		);
+		this.userMessage = `No hay transcripción en ${language} disponible para el video ${videoId}.`;
+	}
+}
+
+/**
+ * Error thrown when the requested language is not supported
+ */
+export class UnsupportedLanguageError extends TranscriptionError {
+	readonly statusCode = 400;
+	readonly errorCode = 'UNSUPPORTED_LANGUAGE';
+	readonly userMessage: string;
+
+	constructor(
+		language: string,
+		supportedLanguages: string[],
+		context?: Record<string, unknown>,
+	) {
+		super(
+			`Unsupported language: ${language}. Supported languages: ${supportedLanguages.join(', ')}`,
+			context,
+		);
+		this.userMessage = `El idioma ${language} no está soportado. Idiomas disponibles: ${supportedLanguages.join(', ')}.`;
+	}
+}
+
+/**
+ * Error thrown when video ID format is invalid
+ */
+export class InvalidVideoIdError extends TranscriptionError {
+	readonly statusCode = 400;
+	readonly errorCode = 'INVALID_VIDEO_ID';
+	readonly userMessage: string;
+
+	constructor(videoId: string, context?: Record<string, unknown>) {
+		super(`Invalid YouTube video ID: ${videoId}`, context);
+		this.userMessage = `El ID del video ${videoId} no es válido. Debe ser un ID de YouTube de 11 caracteres.`;
+	}
+}
+
+/**
+ * Error thrown when rate limited by external services
+ */
+export class RateLimitError extends TranscriptionError {
+	readonly statusCode = 429;
+	readonly errorCode = 'RATE_LIMITED';
+	readonly userMessage: string;
+
+	constructor(retryAfter?: number, context?: Record<string, unknown>) {
+		super('Rate limited by external service', context);
+		const waitTime = retryAfter
+			? ` Intente nuevamente en ${retryAfter} segundos.`
+			: ' Intente nuevamente más tarde.';
+		this.userMessage = `Demasiadas solicitudes.${waitTime}`;
+	}
+}
+
+/**
+ * Error thrown when the service is temporarily unavailable
+ */
+export class ServiceUnavailableError extends TranscriptionError {
+	readonly statusCode = 503;
+	readonly errorCode = 'SERVICE_UNAVAILABLE';
+	readonly userMessage: string;
+
+	constructor(serviceName: string, context?: Record<string, unknown>) {
+		super(`Service unavailable: ${serviceName}`, context);
+		this.userMessage = `El servicio de ${serviceName} no está disponible temporalmente. Intente nuevamente más tarde.`;
+	}
+}
+
+/**
+ * Error thrown when yt-dlp process fails
+ */
+export class YtDlpError extends TranscriptionError {
+	readonly statusCode = 500;
+	readonly errorCode = 'YTDLP_ERROR';
+	readonly userMessage: string;
+
+	constructor(
+		exitCode: number,
+		stderr: string,
+		context?: Record<string, unknown>,
+	) {
+		super(`yt-dlp failed with exit code ${exitCode}: ${stderr}`, context);
+		this.userMessage =
+			'Error al procesar el video. Verifique que el enlace sea válido y que el video tenga subtítulos disponibles.';
+	}
+}
+
+/**
+ * Error thrown when file operations fail
+ */
+export class FileOperationError extends TranscriptionError {
+	readonly statusCode = 500;
+	readonly errorCode = 'FILE_OPERATION_ERROR';
+	readonly userMessage: string;
+
+	constructor(
+		operation: string,
+		filePath: string,
+		originalError: Error,
+		context?: Record<string, unknown>,
+	) {
+		super(
+			`File operation '${operation}' failed for ${filePath}: ${originalError.message}`,
+			context,
+		);
+		this.userMessage =
+			'Error interno del servidor al procesar los archivos de transcripción.';
+	}
+}
+
+/**
+ * Error thrown when parsing subtitle files fails
+ */
+export class SubtitleParsingError extends TranscriptionError {
+	readonly statusCode = 500;
+	readonly errorCode = 'SUBTITLE_PARSING_ERROR';
+	readonly userMessage: string;
+
+	constructor(
+		fileName: string,
+		originalError: Error,
+		context?: Record<string, unknown>,
+	) {
+		super(
+			`Failed to parse subtitle file ${fileName}: ${originalError.message}`,
+			context,
+		);
+		this.userMessage =
+			'Error al procesar el archivo de subtítulos. El formato puede estar corrupto.';
+	}
+}
+
+/**
+ * Check if an error is a TranscriptionError
+ */
+export function isTranscriptionError(
+	error: unknown,
+): error is TranscriptionError {
+	return error instanceof TranscriptionError;
+}
+
+/**
+ * Supported languages for transcription
+ */
+export const SUPPORTED_LANGUAGES = ['es', 'en', 'es-419', 'es-ES'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+/**
+ * Validate if a language is supported
+ */
+export function isSupportedLanguage(
+	language: string,
+): language is SupportedLanguage {
+	return SUPPORTED_LANGUAGES.includes(language as SupportedLanguage);
+}

--- a/apps/transcripter/src/index.ts
+++ b/apps/transcripter/src/index.ts
@@ -19,13 +19,7 @@ app.use(
 
 app.route('/', aristocratTranscripterCoreRouter);
 
-const SERVER_PORT = process.env.PORT || 3002;
-
-console.log(
-	`Transcript service running on port ${SERVER_PORT} with Bun and Hono`,
-);
-
 export default {
-	port: SERVER_PORT,
+	port: process.env.PORT,
 	fetch: app.fetch,
 };

--- a/apps/transcripter/src/routers/core.ts
+++ b/apps/transcripter/src/routers/core.ts
@@ -1,11 +1,14 @@
 import { Hono } from 'hono';
+import {
+	isSupportedLanguage,
+	isTranscriptionError,
+	UnsupportedLanguageError,
+} from '@/errors';
 import { authenticationMiddleware } from '@/middlewares/auth';
 import { TranscriptService } from '@/services/transcript';
 import type { TranscriptRequest } from '@/types';
-import {
-	InvalidVideoIdError,
-	validateAndSanitizeVideoId,
-} from '@/utils/validation';
+import { logger } from '@/utils/logger';
+import { validateAndSanitizeVideoId } from '@/utils/validation';
 
 const router = new Hono<{ Variables: { userId: string } }>();
 const transcriptService = new TranscriptService();
@@ -14,17 +17,47 @@ export const aristocratTranscripterCoreRouter = router.post(
 	'/extract',
 	authenticationMiddleware,
 	async (c) => {
+		const requestId = `req_${Date.now()}_${Math.random().toString(36).substring(2)}`;
+
 		try {
 			const { videoId, language = 'es' }: TranscriptRequest =
 				await c.req.json();
 			const userId = c.get('userId');
 
-			console.log(
-				`Authenticated request from user ${userId} for video: ${videoId}`,
-			);
+			logger.info('Transcript extraction request received', {
+				requestId,
+				userId,
+				videoId,
+				language,
+			});
 
+			// Validate required fields
 			if (!videoId) {
-				return c.json({ error: 'videoId is required' }, 400);
+				return c.json(
+					{
+						error: 'El ID del video es requerido',
+						errorCode: 'MISSING_VIDEO_ID',
+						requestId,
+					},
+					400,
+				);
+			}
+
+			// Validate language support
+			if (!isSupportedLanguage(language)) {
+				const supportedLanguageError = new UnsupportedLanguageError(
+					language,
+					['es', 'en', 'es-419', 'es-ES'],
+					{ requestId, userId },
+				);
+				return c.json(
+					{
+						error: supportedLanguageError.userMessage,
+						errorCode: supportedLanguageError.errorCode,
+						requestId,
+					},
+					supportedLanguageError.statusCode,
+				);
 			}
 
 			// Validate and sanitize the video ID to prevent command injection
@@ -32,8 +65,15 @@ export const aristocratTranscripterCoreRouter = router.post(
 			try {
 				sanitizedVideoId = validateAndSanitizeVideoId(videoId);
 			} catch (validationError) {
-				if (validationError instanceof InvalidVideoIdError) {
-					return c.json({ error: validationError.message }, 400);
+				if (isTranscriptionError(validationError)) {
+					return c.json(
+						{
+							error: validationError.userMessage,
+							errorCode: validationError.errorCode,
+							requestId,
+						},
+						validationError.statusCode,
+					);
 				}
 				throw validationError;
 			}
@@ -41,20 +81,53 @@ export const aristocratTranscripterCoreRouter = router.post(
 			const result = await transcriptService.extractTranscript(
 				sanitizedVideoId,
 				language,
+				userId,
 			);
+
+			logger.info('Transcript extraction completed successfully', {
+				requestId,
+				userId,
+				videoId: sanitizedVideoId,
+				language,
+				segments: result.segments,
+			});
 
 			return c.json({
 				transcript: result.transcript,
 				videoId: sanitizedVideoId,
 				segments: result.segments,
 				file: result.file,
+				requestId,
 			});
 		} catch (extractionError) {
-			console.error('Transcript extraction failed:', extractionError);
+			// Handle TranscriptionError instances with proper status codes and user messages
+			if (isTranscriptionError(extractionError)) {
+				logger.error('Transcription error occurred', extractionError, {
+					requestId,
+				});
+
+				return c.json(
+					{
+						error: extractionError.userMessage,
+						errorCode: extractionError.errorCode,
+						requestId,
+					},
+					extractionError.statusCode,
+				);
+			}
+
+			// Handle unexpected errors
+			logger.error(
+				'Unexpected error during transcription',
+				extractionError as Error,
+				{ requestId },
+			);
+
 			return c.json(
 				{
-					error: (extractionError as Error).message,
-					videoId: (await c.req.json().catch(() => ({})))?.videoId,
+					error: 'Error interno del servidor. Intente nuevamente más tarde.',
+					errorCode: 'INTERNAL_SERVER_ERROR',
+					requestId,
 				},
 				500,
 			);

--- a/apps/transcripter/src/utils/files.ts
+++ b/apps/transcripter/src/utils/files.ts
@@ -1,26 +1,80 @@
 import { $ } from 'bun';
+import {
+	FileOperationError,
+	TranscriptNotAvailableError,
+	VideoNotFoundError,
+	YtDlpError,
+} from '@/errors';
+import { logExternalServiceError, logger } from '@/utils/logger';
+import { withRetry, YT_DLP_RETRY_OPTIONS } from '@/utils/retry';
 
 export async function downloadSubtitles(
 	videoId: string,
 	language: string,
 	tempDir: string,
 ): Promise<string[]> {
-	await $`cd ${tempDir} && yt-dlp --write-auto-sub --write-sub --sub-langs "${language},en,es-419,es-ES" --skip-download --output "%(id)s.%(ext)s" "https://youtube.com/watch?v=${videoId}"`;
+	try {
+		return await withRetry(async () => {
+			const process = $`cd ${tempDir} && yt-dlp --write-auto-sub --write-sub --sub-langs "${language},en,es-419,es-ES" --skip-download --output "%(id)s.%(ext)s" "https://youtube.com/watch?v=${videoId}"`;
 
-	const directoryListing = await $`ls ${tempDir}`.text();
-	const availableSubtitleFiles = directoryListing
-		.split('\n')
-		.filter(
-			(fileName) =>
-				fileName.trim() &&
-				(fileName.endsWith('.vtt') || fileName.endsWith('.srt')),
-		);
+			const result = await process;
 
-	if (availableSubtitleFiles.length === 0) {
-		throw new Error(`No subtitle files found for video ${videoId}`);
+			// Check if yt-dlp failed
+			if (result.exitCode !== 0) {
+				const stderr = await result.stderr.text();
+
+				// Parse specific error types from yt-dlp output
+				if (
+					stderr.includes('Video unavailable') ||
+					stderr.includes('Private video') ||
+					stderr.includes('This video is not available')
+				) {
+					throw new VideoNotFoundError(videoId, { stderr });
+				}
+
+				if (
+					stderr.includes('No automatic captions') ||
+					stderr.includes('No subtitles')
+				) {
+					throw new TranscriptNotAvailableError(videoId, language, { stderr });
+				}
+
+				throw new YtDlpError(result.exitCode, stderr, { videoId, language });
+			}
+
+			const directoryListing = await $`ls ${tempDir}`.text();
+			const availableSubtitleFiles = directoryListing
+				.split('\n')
+				.filter(
+					(fileName) =>
+						fileName.trim() &&
+						(fileName.endsWith('.vtt') || fileName.endsWith('.srt')),
+				);
+
+			if (availableSubtitleFiles.length === 0) {
+				throw new TranscriptNotAvailableError(videoId, language, {
+					reason: 'No subtitle files found after download',
+					tempDir,
+				});
+			}
+
+			logger.info('Subtitles downloaded successfully', {
+				videoId,
+				language,
+				fileCount: availableSubtitleFiles.length,
+				files: availableSubtitleFiles,
+			});
+
+			return availableSubtitleFiles;
+		}, YT_DLP_RETRY_OPTIONS);
+	} catch (error) {
+		logExternalServiceError('yt-dlp', error as Error, {
+			videoId,
+			language,
+			tempDir,
+		});
+		throw error;
 	}
-
-	return availableSubtitleFiles;
 }
 
 export function selectBestSubtitleFile(availableFiles: string[]): string {
@@ -33,10 +87,30 @@ export function selectBestSubtitleFile(availableFiles: string[]): string {
 
 export async function createTempDirectory(videoId: string): Promise<string> {
 	const temporaryDirectory = `/tmp/transcript_${videoId}_${Date.now()}`;
-	await $`mkdir -p ${temporaryDirectory}`;
-	return temporaryDirectory;
+
+	try {
+		await $`mkdir -p ${temporaryDirectory}`;
+		logger.debug('Temporary directory created', {
+			tempDir: temporaryDirectory,
+			videoId,
+		});
+		return temporaryDirectory;
+	} catch (error) {
+		throw new FileOperationError('create', temporaryDirectory, error as Error, {
+			videoId,
+		});
+	}
 }
 
 export async function cleanupTempDirectory(tempDir: string): Promise<void> {
-	await $`rm -rf ${tempDir}`.nothrow();
+	try {
+		await $`rm -rf ${tempDir}`.nothrow();
+		logger.debug('Temporary directory cleaned up', { tempDir });
+	} catch (error) {
+		logger.warn('Failed to cleanup temporary directory', {
+			tempDir,
+			error: (error as Error).message,
+		});
+		// Don't throw here since cleanup is not critical
+	}
 }

--- a/apps/transcripter/src/utils/logger.ts
+++ b/apps/transcripter/src/utils/logger.ts
@@ -1,0 +1,169 @@
+/**
+ * Comprehensive error logging utility
+ */
+
+export interface LogContext {
+	videoId?: string;
+	userId?: string;
+	language?: string;
+	operation?: string;
+	timestamp?: string;
+	duration?: number;
+	[key: string]: unknown;
+}
+
+export enum LogLevel {
+	ERROR = 'ERROR',
+	WARN = 'WARN',
+	INFO = 'INFO',
+	DEBUG = 'DEBUG',
+}
+
+/**
+ * Logger class for structured logging
+ */
+export class Logger {
+	private static instance: Logger;
+
+	private constructor() {}
+
+	static getInstance(): Logger {
+		if (!Logger.instance) {
+			Logger.instance = new Logger();
+		}
+		return Logger.instance;
+	}
+
+	private formatLog(
+		level: LogLevel,
+		message: string,
+		context?: LogContext,
+	): string {
+		const timestamp = new Date().toISOString();
+		const logEntry = {
+			timestamp,
+			level,
+			message,
+			...context,
+		};
+		return JSON.stringify(logEntry);
+	}
+
+	error(message: string, error?: Error, context?: LogContext): void {
+		const errorContext = {
+			...context,
+			errorName: error?.name,
+			errorMessage: error?.message,
+			errorStack: error?.stack,
+		};
+		console.error(this.formatLog(LogLevel.ERROR, message, errorContext));
+	}
+
+	warn(message: string, context?: LogContext): void {
+		console.warn(this.formatLog(LogLevel.WARN, message, context));
+	}
+
+	info(message: string, context?: LogContext): void {
+		console.info(this.formatLog(LogLevel.INFO, message, context));
+	}
+
+	debug(message: string, context?: LogContext): void {
+		if (process.env.NODE_ENV === 'development') {
+			console.debug(this.formatLog(LogLevel.DEBUG, message, context));
+		}
+	}
+}
+
+/**
+ * Default logger instance
+ */
+export const logger = Logger.getInstance();
+
+/**
+ * Log transcription operation start
+ */
+export function logTranscriptionStart(
+	videoId: string,
+	language: string,
+	userId?: string,
+): void {
+	logger.info('Transcription started', {
+		videoId,
+		language,
+		userId,
+		operation: 'transcription_start',
+	});
+}
+
+/**
+ * Log transcription operation success
+ */
+export function logTranscriptionSuccess(
+	videoId: string,
+	language: string,
+	segmentCount: number,
+	duration: number,
+	userId?: string,
+): void {
+	logger.info('Transcription completed successfully', {
+		videoId,
+		language,
+		userId,
+		segmentCount,
+		duration,
+		operation: 'transcription_success',
+	});
+}
+
+/**
+ * Log transcription operation failure
+ */
+export function logTranscriptionError(
+	error: Error,
+	videoId?: string,
+	language?: string,
+	userId?: string,
+	duration?: number,
+): void {
+	logger.error('Transcription failed', error, {
+		videoId,
+		language,
+		userId,
+		duration,
+		operation: 'transcription_error',
+	});
+}
+
+/**
+ * Log retry attempt
+ */
+export function logRetryAttempt(
+	operation: string,
+	attempt: number,
+	maxRetries: number,
+	error: Error,
+	context?: LogContext,
+): void {
+	logger.warn(`Retry attempt ${attempt}/${maxRetries} for ${operation}`, {
+		...context,
+		operation,
+		attempt,
+		maxRetries,
+		retryReason: error.message,
+	});
+}
+
+/**
+ * Log external service error
+ */
+export function logExternalServiceError(
+	service: string,
+	error: Error,
+	context?: LogContext,
+): void {
+	logger.error(`External service error: ${service}`, error, {
+		...context,
+		service,
+		operation: 'external_service_error',
+	});
+}

--- a/apps/transcripter/src/utils/retry.ts
+++ b/apps/transcripter/src/utils/retry.ts
@@ -1,0 +1,111 @@
+/**
+ * Retry utilities for handling transient failures
+ */
+
+export interface RetryOptions {
+	maxRetries: number;
+	baseDelay: number;
+	maxDelay: number;
+	backoffMultiplier: number;
+	retryCondition?: (error: Error) => boolean;
+}
+
+const DEFAULT_RETRY_OPTIONS: RetryOptions = {
+	maxRetries: 3,
+	baseDelay: 1000,
+	maxDelay: 10000,
+	backoffMultiplier: 2,
+	retryCondition: (error: Error) => {
+		// Default: retry on network errors and server errors
+		const message = error.message.toLowerCase();
+		return (
+			message.includes('network') ||
+			message.includes('timeout') ||
+			message.includes('connection') ||
+			message.includes('econnreset') ||
+			message.includes('enotfound') ||
+			message.includes('temporary failure')
+		);
+	},
+};
+
+/**
+ * Sleep for the specified number of milliseconds
+ */
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Calculate delay with exponential backoff
+ */
+function calculateDelay(attempt: number, options: RetryOptions): number {
+	const delay = Math.min(
+		options.baseDelay * options.backoffMultiplier ** attempt,
+		options.maxDelay,
+	);
+	// Add jitter to prevent thundering herd
+	return delay + Math.random() * 0.1 * delay;
+}
+
+/**
+ * Retry a function with exponential backoff
+ */
+export async function withRetry<T>(
+	fn: () => Promise<T>,
+	options: Partial<RetryOptions> = {},
+): Promise<T> {
+	const config = { ...DEFAULT_RETRY_OPTIONS, ...options };
+	let lastError: Error | undefined;
+
+	for (let attempt = 0; attempt <= config.maxRetries; attempt++) {
+		try {
+			return await fn();
+		} catch (error) {
+			lastError = error as Error;
+
+			// Don't retry if this is the last attempt
+			if (attempt === config.maxRetries) {
+				break;
+			}
+
+			// Check if we should retry this error
+			if (config.retryCondition && !config.retryCondition(lastError)) {
+				break;
+			}
+
+			const delay = calculateDelay(attempt, config);
+			console.warn(
+				`Attempt ${attempt + 1} failed, retrying in ${Math.round(delay)}ms:`,
+				lastError.message,
+			);
+
+			await sleep(delay);
+		}
+	}
+
+	throw lastError || new Error('Retry operation failed without error');
+}
+
+/**
+ * Specific retry configuration for yt-dlp operations
+ */
+export const YT_DLP_RETRY_OPTIONS: Partial<RetryOptions> = {
+	maxRetries: 3,
+	baseDelay: 2000,
+	maxDelay: 15000,
+	backoffMultiplier: 2,
+	retryCondition: (error: Error) => {
+		const message = error.message.toLowerCase();
+		return (
+			message.includes('network') ||
+			message.includes('timeout') ||
+			message.includes('connection') ||
+			message.includes('temporary failure') ||
+			message.includes('server error') ||
+			message.includes('503') ||
+			message.includes('502') ||
+			message.includes('504')
+		);
+	},
+};

--- a/apps/transcripter/src/utils/validation.ts
+++ b/apps/transcripter/src/utils/validation.ts
@@ -1,6 +1,10 @@
 /**
  * YouTube video ID validation utilities
  */
+import { InvalidVideoIdError } from '@/errors';
+
+// Re-export for tests
+export { InvalidVideoIdError };
 
 /**
  * YouTube video ID regex pattern
@@ -8,18 +12,6 @@
  * containing alphanumeric characters, hyphens, and underscores
  */
 const YOUTUBE_VIDEO_ID_REGEX = /^[a-zA-Z0-9_-]{11}$/;
-
-/**
- * Error thrown when a video ID is invalid
- */
-export class InvalidVideoIdError extends Error {
-	constructor(videoId: string) {
-		super(
-			`Invalid YouTube video ID: ${videoId}. Video IDs must be exactly 11 characters containing only letters, numbers, hyphens, and underscores.`,
-		);
-		this.name = 'InvalidVideoIdError';
-	}
-}
 
 /**
  * Validates if a string is a valid YouTube video ID
@@ -42,7 +34,9 @@ export function isValidYouTubeVideoId(videoId: string): boolean {
  */
 export function validateAndSanitizeVideoId(videoId: string): string {
 	if (typeof videoId !== 'string') {
-		throw new InvalidVideoIdError(String(videoId));
+		throw new InvalidVideoIdError(String(videoId), {
+			originalType: typeof videoId,
+		});
 	}
 
 	// Remove any whitespace
@@ -50,7 +44,7 @@ export function validateAndSanitizeVideoId(videoId: string): string {
 
 	// Validate the sanitized ID
 	if (!isValidYouTubeVideoId(sanitized)) {
-		throw new InvalidVideoIdError(sanitized);
+		throw new InvalidVideoIdError(sanitized, { originalValue: videoId });
 	}
 
 	return sanitized;

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,11 @@
 			"cache": false,
 			"persistent": true
 		},
+		"test": {
+			"dependsOn": ["^build"],
+			"outputs": ["coverage/**"],
+			"cache": true
+		},
 		"db:push": {
 			"cache": false,
 			"persistent": true


### PR DESCRIPTION
This pull request introduces several updates to the `transcripter` app, including enhancements to documentation, testing infrastructure, error handling, and retry utilities. The most notable changes involve the addition of comprehensive tests for custom error classes and services, updates to the Jest configuration, and improvements to the project's documentation.

### Documentation Updates:
* **`CLAUDE.md`:** Expanded documentation to include new testing commands (`bun run test`, `bun run test:watch`, `bun run test:coverage`) and details about the `transcripter` app's architecture, environment variables, and shared database package. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R24-R36) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L49-R60) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L75-R96)

### Testing Enhancements:
* **Mock Implementation:** Added a Jest mock for Bun shell commands to facilitate testing (`apps/transcripter/__tests__/__mocks__/bun.ts`).
* **Error Class Tests:** Introduced comprehensive tests for custom error classes, ensuring proper validation and handling of various error scenarios (`apps/transcripter/__tests__/errors/index.test.ts`).
* **Transcript Service Tests:** Added tests for the `TranscriptService`, covering error propagation, file handling, and subtitle parsing (`apps/transcripter/__tests__/services/transcript.test.ts`).
* **Retry Utility Tests:** Implemented tests for the retry utility, including scenarios for retry conditions and configuration validation (`apps/transcripter/__tests__/utils/retry.test.ts`).

### Configuration Updates:
* **Jest Configuration:** Updated Jest's `moduleNameMapper` to include a mapping for Bun (`apps/transcripter/jest.config.ts`).

### Development Script:
* **`dev.sh`:** Removed unnecessary echo statement for cleaner logs when starting the development container (`apps/transcripter/scripts/dev.sh`).